### PR TITLE
Update keyserver

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 
-dockerhost_keyserver                : "hkp://p80.pool.sks-keyservers.net:80"
+dockerhost_keyserver                : "hkps://keys.openpgp.org"
 dockerhost_id                       : "58118E89F3A912897C070ADBF76221572C52609D"
 
 docker_compose_file                 : "docker-compose-Linux-{{ ansible_userspace_architecture }}-{{ docker_compose_version }}"


### PR DESCRIPTION
[SKS Keyservers are no longer available][1]; switch to` keys.openpgp.org`.  
It has the dockerproject aptitude repository key (`58118E89F3A912897C070ADBF76221572C52609D`) so it should be a suitable replacement.

```sh
root@4482e6c0747c:/app# apt-key adv --no-tty --keyserver hkps://keys.openpgp.org --recv 58118E89F3A912897C070ADBF76221572C52609D
Executing: /tmp/apt-key-gpghome.UBsIFCZ3vS/gpg.1.sh --no-tty --keyserver hkps://keys.openpgp.org --recv 58118E89F3A912897C070ADBF76221572C52609D
gpg: requesting key 2C52609D from hkps server keys.openpgp.org
gpg: key 2C52609D: no user ID
gpg: Total number processed: 1
```

[1]: https://code.firstlook.media/the-death-of-sks-pgp-keyservers-and-how-first-look-media-is-handling-it